### PR TITLE
Fix; sleep failing in `init_worker`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -153,6 +153,9 @@ The return value will be `true`, or `nil` and an error message.
 This method can be called repeatedly to update the settings, except for the `shm` value which
 cannot be changed after the initial configuration.
 
+NOTE: the `wait_interval` is executed using the `ngx.sleep` function. In contexts where this 
+function is not available (eg. `init_worker`) it will execute a busy-wait to execute the delay.
+
 [Back to TOC](#table-of-contents)
 
 configured

--- a/lib/resty/worker/events.lua
+++ b/lib/resty/worker/events.lua
@@ -115,10 +115,6 @@ end
 local function post_event(source, event, data, unique)
     local json, err, event_id, success
 
-    _dict:add(KEY_LAST_ID, 0)
-    event_id, err = _dict:incr(KEY_LAST_ID, 1)
-    if err then return event_id, err end
-
     json, err = cjson.encode({
             source = source,
             event = event,
@@ -127,6 +123,10 @@ local function post_event(source, event, data, unique)
             pid = _pid,
         })
     if not json then return json, err end
+
+    _dict:add(KEY_LAST_ID, 0)
+    event_id, err = _dict:incr(KEY_LAST_ID, 1)
+    if err then return event_id, err end
 
     success, err = _dict:add(KEY_DATA..tostring(event_id), json, _timeout)
     if not success then return success, err end


### PR DESCRIPTION
Becasue the `ngx.sleep` function isn't always available, the if a synchronization issue occurs, an error was thrown that it wasn't available.

in those cases an alternative (busy-wait) is now being used
