### PR TITLE
feat(handlers) allow for weak references

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,6 +18,7 @@ Table of Contents
     * [post](#post)
     * [post_local](#post_local)
     * [register](#register)
+    * [register_weak](#register_weak)
     * [unregister](#unregister)
 * [Installation](#installation)
 * [TODO](#todo)
@@ -323,6 +324,15 @@ the configured `timeout` value, events will be dropped!
 
 *Note*: to receive the process own `started` event, the handler must be registered before
 calling [configure](#configure)
+
+[Back to TOC](#table-of-contents)
+
+register_weak
+-------------
+`syntax: events.register_weak(callback, source, event1, event2, ...)`
+
+This function is identical to `register`, with the exception that the module
+will only hold _weak references_ to the `callback` function.
 
 [Back to TOC](#table-of-contents)
 

--- a/lib/resty/worker/events.lua
+++ b/lib/resty/worker/events.lua
@@ -12,8 +12,6 @@ local cjson = require("cjson.safe").new()
 local get_pid = ngx.worker.pid
 local now = ngx.now
 local sleep = ngx.sleep
-local tinsert = table.insert
-local tremove = table.remove
 
 -- event keys to shm
 local KEY_LAST_ID = "events-last"         -- ID of last event posted
@@ -30,19 +28,36 @@ local _wait_max      -- how long (in seconds) to wait when we have an event id,
                      -- but no data, for the data to show up.
 local _wait_interval -- interval between tries when event data is unavailable
 
+local dump = function(...)
+  ngx.log(ngx.DEBUG,"\027[31m", require("pl.pretty").write({...}),"\027[0m")
+end
+
 -- defaults
 local DEFAULT_TIMEOUT = 2
 local DEFAULT_INTERVAL = 1
 local DEFAULT_WAIT_MAX = 0.5
 local DEFAULT_WAIT_INTERVAL = 0.010
 
+-- creates a new level strcuture for the callback tree
+local new_struct = function()
+  return {
+    weak_count = 0,
+    weak_list = setmetatable({},{ __mode = "v"}),
+    strong_count = 0,
+    strong_list = {},
+    subs = {} -- nested sub tables; source based, and event based (initial one is global)
+  }
+end
 -- metatable that auto creates sub tables if a key is not found
 -- __index function to do the auto table magic
 local autotable__index = function(self, key)
   local mt = getmetatable(self)
-  local t = {}
+  local t = new_struct()
   if mt.depth ~= 1 then
-    setmetatable(t, { __index = mt.__index, depth = mt.depth - 1})
+    setmetatable(t.subs, {
+        __index = mt.__index,
+        depth = mt.depth - 1,
+    })
   end
   self[key] = t
   return t
@@ -52,29 +67,29 @@ end
 -- @param depth (optional, default 1) how deep to auto-generate tables. The last
 -- table in the chain generated will itself not be an auto-table. If `depth == 0` then
 -- there is no limit.
+-- @param mode (optional) set the weak table behavior
 -- @return new auto-table
 function autotable(depth)
-  return setmetatable({}, {__index = autotable__index, depth = depth })
+  
+  local at = new_struct()
+  setmetatable(at.subs, {
+            __index = autotable__index,
+            depth = depth,
+          })
+  return at
 end
 
 -- callbacks
 local _callbacks = autotable(2)
--- _callbacks; array = global handlers called on every event
--- _callbacks; hash  = subtables for a specific eventsource
+-- strong/weak; array = global handlers called on every event
+-- strong/weak; hash  = subtables for a specific eventsource
 -- eventsource-sub-table has the same structure, except the hash part contains 
 -- not 'eventsource', but 'event' specific handlers, no more sub tables
 
 
 local _M = {
-  _VERSION = '0.3.0',
+  _VERSION = '0.3.1',
 }
-
-if not ngx.config
-  or not ngx.config.ngx_lua_version
-  or ngx.config.ngx_lua_version < 9005
-then
-  error("ngx_lua 0.9.5+ required")
-end
 
 local function info(...)
   log(INFO, "worker-events: ", ...)
@@ -133,30 +148,51 @@ local function post_event(source, event, data, unique)
   return event_id
 end
 
-local function do_handlerlist(list, source, event, data, pid)
+
+local function do_handlerlist(handler_list, source, event, data, pid)
   local err, success
 
-  for _, handler in ipairs(list) do
-    success, err = pcall(handler, data, event, source, pid)
-    if not success then
-      errlog("event callback failed; source=",source,
-             ", event=",event,", pid=",pid, " error='", tostring(err),
-             "', data="..cjson.encode(data))
+  local count_key = "weak_count"
+  local list_key = "weak_list"
+  while true do
+    local i = 1
+    local list = handler_list[list_key]
+    while i <= handler_list[count_key] do
+      local handler = list[i]
+      if type(handler) ~= "function" then
+        -- handler was removed, unregistered, or GC'ed, cleanup.
+        -- Entry is nil, but recreated as a table due to the auto-table
+        list[i] = list[handler_list[count_key]]
+        list[handler_list[count_key]] = nil
+        handler_list[count_key] = handler_list[count_key] - 1
+      else
+        success, err = pcall(handler, data, event, source, pid)
+        if not success then
+          errlog("event callback failed; source=",source,
+                 ", event=",event,", pid=",pid, " error='", tostring(err),
+                 "', data="..cjson.encode(data))
+        end
+        i = i + 1
+      end
     end
+    if list_key == "strong_list" then
+      return
+    end
+    count_key = "strong_count"
+    list_key = "strong_list"
   end
 end
 
-local function do_event(source, event, data, pid)
-  local list
 
+local function do_event(source, event, data, pid)
   debug("handling event; source=",source,
          ", event=",event,", pid=",pid,", data=",tostring(data))
 
-  list = _callbacks
+  local list = _callbacks
   do_handlerlist(list, source, event, data, pid)
-  list = list[source]
+  list = list.subs[source]
   do_handlerlist(list, source, event, data, pid)
-  list = list[event]
+  list = list.subs[event]
   do_handlerlist(list, source, event, data, pid)
 end
 
@@ -341,28 +377,41 @@ do_timer = function(premature)
   return true
 end
 
--- registers an event handler callback.
--- signature; callback(source, event, data, originating_pid)
--- @param callback the eventhandler callback to add
--- @param source (optional) if given only this source is being called for
--- @param ... (optional) event names (0 or more) to register for
--- @return true
-_M.register = function(callback, source, ...)
+-- @param mode either "weak" or "strong"
+local register = function(callback, mode, source, ...)
   assert(type(callback) == "function", "expected function, got: "..
          type(callback))
 
+  local count_key, list_key
+  if mode == "weak" then
+    count_key = "weak_count"
+    list_key = "weak_list"
+  else
+    count_key = "strong_count"
+    list_key = "strong_list"
+  end 
+    
   if not source then
     -- register as global event handler
-    tinsert(_callbacks, callback)
+    local list = _callbacks
+    local n = list[count_key] + 1
+    list[count_key] = n
+    list[list_key][n] = callback
   else
     local events = {...}
     if #events == 0 then
       -- register as an eventsource handler
-      tinsert(_callbacks[source], callback)
+      local list = _callbacks.subs[source]
+      local n = list[count_key] + 1
+      list[count_key] = n
+      list[list_key][n] = callback
     else
       -- register as an event specific handler, for multiple events
       for _, event in ipairs(events) do
-        tinsert(_callbacks[source][event], callback)
+        local list = _callbacks.subs[source].subs[event]
+        local n = list[count_key] + 1
+        list[count_key] = n
+        list[list_key][n] = callback
       end
     end
   end
@@ -370,7 +419,29 @@ _M.register = function(callback, source, ...)
 end
 
 
+-- registers an event handler callback.
+-- signature; callback(source, event, data, originating_pid)
+-- @param callback the eventhandler callback to add
+-- @param source (optional) if given only this source is being called for
+-- @param ... (optional) event names (0 or more) to register for
+-- @return true
+_M.register = function(callback, source, ...)
+  register(callback, "strong", source, ...)
+end
+
+-- registers a weak-event handler callback.
+-- Workerevents will maintain a weak reference to the handler.
+-- signature; callback(source, event, data, originating_pid)
+-- @param callback the eventhandler callback to add
+-- @param source (optional) if given only this source is being called for
+-- @param ... (optional) event names (0 or more) to register for
+-- @return true
+_M.register_weak = function(callback, source, ...)
+  register(callback, "weak", source, ...)
+end
+
 -- unregisters an event handler callback.
+-- Will remove both the weak and strong references.
 -- @param callback the eventhandler callback to remove
 -- @return `true` if it was removed, `false` if it was not in the list. If multiple
 -- eventnames have been specified, `true` means at least 1 occurence was removed
@@ -379,37 +450,52 @@ _M.unregister = function(callback, source, ...)
          type(callback))
        
   local success
-  if not source then
-    -- remove as global event handler
-    for i, cb in ipairs(_callbacks) do
-      if cb == callback then
-        tremove(_callbacks, i)
-        success = true
-      end
-    end
-  else
-    local events = {...}
-    if not next(events) then
-      -- remove as an eventsource handler
-      local target = _callbacks[source]
-      for i, cb in ipairs(target) do
+  local count_key = "weak_count"
+  local list_key = "weak_list"
+  -- NOTE: we only set entries to `nil`, the event runner will
+  -- cleanup and remove those entries to 'heal' the lists
+  while true do
+    local list = _callbacks
+    if not source then
+      -- remove as global event handler
+      for i = 1, list[count_key] do
+        local cb = list[list_key][i]
         if cb == callback then
-          tremove(target, i)
+          list[list_key][i] = nil
           success = true
         end
       end
     else
-      -- remove as an event specific handler, for multiple events
-      for _, event in ipairs(events) do
-        local target = _callbacks[source][event]
-        for i, cb in ipairs(target) do
+      local events = {...}
+      if not next(events) then
+        -- remove as an eventsource handler
+        local target = list.subs[source]
+        for i = 1, target[count_key] do
+          local cb = target[list_key][i]
           if cb == callback then
-            tremove(target, i)
+            target[list_key][i] = nil
             success = true
+          end
+        end
+      else
+        -- remove as an event specific handler, for multiple events
+        for _, event in ipairs(events) do
+          local target = list.subs[source].subs[event]
+          for i = 1, target[count_key] do
+            local cb = target[list_key][i]
+            if cb == callback then
+              target[list_key][i] = nil
+              success = true
+            end
           end
         end
       end
     end
+    if list_key == "strong_list" then
+      break
+    end
+    count_key = "strong_count"
+    list_key = "strong_list"
   end
   
   return (success == true)
@@ -421,6 +507,7 @@ end
 -- interval: interval to poll for events (in seconds)
 -- wait_interval : interval between two tries when an eventid is found, but no data
 -- wait_max: max time to wait for data when event id is found, before discarding
+-- debug   : if true a value `_callbacks` is exported on the module table
 _M.configure = function(opts)
   assert(type(opts) == "table", "Expected a table, got "..type(opts))
 
@@ -504,6 +591,10 @@ _M.configure = function(opts)
     if not success then return success, err end
   else
     _M.poll()
+  end
+
+  if opts.debug then
+    _M._callbacks = _callbacks
   end
 
   return true

--- a/lua-resty-worker-events-0.3.1-1.rockspec
+++ b/lua-resty-worker-events-0.3.1-1.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-worker-events"
-version = "0.3.0-1"
+version = "0.3.1-1"
 source = {
-   url = "https://github.com/Mashape/lua-resty-worker-events/archive/0.3.0.tar.gz",
-   dir = "lua-resty-worker-events-0.3.0"
+   url = "https://github.com/Mashape/lua-resty-worker-events/archive/0.3.1.tar.gz",
+   dir = "lua-resty-worker-events-0.3.1"
 }
 description = {
    summary = "Cross worker eventbus for OpenResty",


### PR DESCRIPTION
This prevents the handlers registered to anchor any objects, and hence preventing them from being garbage collected.

When registering event handlers using the new `register_weak` method, the caller must anchor the handlers. If not, the handler will be GC'ed and will stop receiving/handling events.
