### PR TITLE
fix(poll) add stacktrace to failing event handlers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -394,6 +394,7 @@ History
 
 0.3.2, xx-Apr-2018
 
+- change: add a stacktrace to handler errors
 - fix: failing error handler if value was non-serializable, see issue #5
 - fix: fix a test for the weak handlers
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -9,7 +9,7 @@ use Cwd qw(cwd);
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 6 - 4);
+plan tests => repeat_each() * (blocks() * 6 - 5);
 
 my $pwd = cwd();
 
@@ -746,3 +746,61 @@ GET /t
 ok
 --- error_log
 something went wrong here!
+
+
+
+=== TEST 10: callback error stacktrace
+--- http_config eval
+"$::HttpConfig"
+. q{
+upstream foo.com {
+    server 127.0.0.1:12354;
+}
+
+server {
+    listen 12354;
+    location = /status {
+        return 200;
+    }
+}
+
+lua_shared_dict worker_events 1m;
+init_worker_by_lua '
+    ngx.shared.worker_events:flush_all()
+';
+}
+--- config
+    location = /t {
+        access_log off;
+        content_by_lua '
+            ngx.shared.worker_events:flush_all()
+            local we = require "resty.worker.events"
+            local ok, err = we.configure{
+                shm = "worker_events",
+            }
+
+            local error_func = function()
+              error("something went wrong here!")
+            end
+            local in_between = function()
+              error_func() -- nested call to check stack trace
+            end
+            local test_callback = function(source, event, data, pid)
+              in_between() -- nested call to check stack trace
+            end
+
+            we.register(test_callback)
+            we.post("content_by_lua","test_event")
+
+            ngx.say("ok")
+        ';
+    }
+
+--- request
+GET /t
+--- response_body
+ok
+--- error_log
+something went wrong here!
+in function 'error_func'
+in function 'in_between'


### PR DESCRIPTION
Stacktrace from the included test:

Before (without stacktrace):
```
2018/04/10 20:35:01 [debug] 16467#0: *2 [lua] events.lua:132: debug(): worker-events: handling event; source=content_by_lua, event=test_event, pid=16467, data=nil
2018/04/10 20:35:01 [error] 16467#0: *2 [lua] events.lua:124: errlog(): worker-events: event callback failed; source=content_by_lua, event=test_event, pid=16467 error='content_by_lua(nginx.conf:78):8: something went wrong here!', data=nil, client: 127.0.0.1, server: localhost, request: "GET /t HTTP/1.1", host: "localhost"
2018/04/10 20:35:01 [debug] 16467#0: fetching key "events-last" in shared dict "worker_events"
```

After (with stacktrace):
```
2018/04/10 20:35:01 [debug] 16467#0: *2 [lua] events.lua:132: debug(): worker-events: handling event; source=content_by_lua, event=test_event, pid=16467, data=nil
2018/04/10 20:35:01 [error] 16467#0: *2 [lua] events.lua:124: errlog(): worker-events: event callback failed; source=content_by_lua, event=test_event, pid=16467 error='content_by_lua(nginx.conf:78):8: something went wrong here!
stack traceback:
	[C]: in function 'error'
	content_by_lua(nginx.conf:78):8: in function 'error_func'
	content_by_lua(nginx.conf:78):11: in function <content_by_lua(nginx.conf:78):10>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/resty/worker/events.lua:190: in function 'do_handlerlist'
	/usr/local/share/lua/5.1/resty/worker/events.lua:220: in function 'do_event_json'
	/usr/local/share/lua/5.1/resty/worker/events.lua:366: in function 'post'
	content_by_lua(nginx.conf:78):17: in function <content_by_lua(nginx.conf:78):1>', data=nil, client: 127.0.0.1, server: localhost, request: "GET /t HTTP/1.1", host: "localhost"
2018/04/10 20:35:01 [debug] 16467#0: fetching key "events-last" in shared dict "worker_events"
```