### PR TITLE
remove timeout setting, rely on lru eviction

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -57,7 +57,7 @@ http {
 
         local ok, err = ev.configure {
             shm = "process_events", -- defined by "lua_shared_dict"
-            timeout = 2,            -- life time of event data in shm
+            timeout = 2,            -- life time of unique event data in shm
             interval = 1,           -- poll interval (seconds)
 
             wait_interval = 0.010,  -- wait before retry fetching event data
@@ -140,13 +140,16 @@ configure
 
 Will initialize the event listener. The `opts` parameter is a Lua table with named options
 
-* `shm`: (required) name of the shared memory to use
-* `timeout`: (optional) timeout of event data stored in shm (in seconds), default 2
+* `shm`: (required) name of the shared memory to use. Event data will not expire, so
+  the module relies on the shm lru mechanism to evict old events from the shm. As such
+  the shm should probably not be used for other purposes.
 * `interval`: (optional) interval to poll for events (in seconds), default 1
 * `wait_interval`: (optional) interval between two tries when a new eventid is found, but the
   data is not available yet (due to asynchronous behaviour of the worker processes)
 * `wait_max`: (optional) max time to wait for data when event id is found, before discarding
   the event. This is a fail-safe setting in case something went wrong.
+* `timeout`: (optional) timeout of unique event data stored in shm (in seconds), default 2.
+  See the `unique` parameter of the [post](#post) method.
 
 The return value will be `true`, or `nil` and an error message.
 

--- a/README.markdown
+++ b/README.markdown
@@ -394,6 +394,10 @@ History
 
 Note: please update version number in the code when releasing a new version!
 
+x.x.x, xxx-May-2018
+
+- fix: timouts in init phases, by removing timeout setting
+
 0.3.2, 11-Apr-2018
 
 - change: add a stacktrace to handler errors

--- a/lua-resty-worker-events-0.3.2-1.rockspec
+++ b/lua-resty-worker-events-0.3.2-1.rockspec
@@ -1,0 +1,25 @@
+package = "lua-resty-worker-events"
+version = "0.3.2-1"
+source = {
+   url = "https://github.com/Kong/lua-resty-worker-events/archive/0.3.2.tar.gz",
+   dir = "lua-resty-worker-events-0.3.2"
+}
+description = {
+   summary = "Cross worker eventbus for OpenResty",
+   detailed = [[
+      lua-resty-worker-events is a module that can emit events
+      to be handled local (in the worker emitting the event), global
+      (in all worker processes), or once (only in one worker).
+      The order of the events is guaranteed the same in all workers.
+   ]],
+   license = "Apache 2.0",
+   homepage = "https://github.com/Kong/lua-resty-worker-events"
+}
+dependencies = {
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["resty.worker.events"] = "lib/resty/worker/events.lua",
+   }
+}

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -371,6 +371,7 @@ init_worker_by_lua '
                 ", data=", data)
             end)
     local ok, err = we.configure{
+        timeout = 0.4,
         shm = "worker_events",
     }
     if not ok then
@@ -388,7 +389,10 @@ init_worker_by_lua '
             we.post("content_by_lua","request1","01234567890")
             we.post("content_by_lua","request2","01234567890", "unique_value")
             we.post("content_by_lua","request3","01234567890", "unique_value")
-            we.post("content_by_lua","request4","01234567890")
+            ngx.sleep(0.5) -- wait for unique timeout to expire
+            we.post("content_by_lua","request4","01234567890", "unique_value")
+            we.post("content_by_lua","request5","01234567890", "unique_value")
+            we.post("content_by_lua","request6","01234567890")
             ngx.print("hello world\\n")
 
         ';
@@ -413,7 +417,9 @@ worker-events: handler event;  source=content_by_lua, event=request1, pid=\d+, d
 worker-events: handling event; source=content_by_lua, event=request2, pid=\d+, data=01234567890
 worker-events: handler event;  source=content_by_lua, event=request2, pid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request4, pid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request4, pid=\d+, data=01234567890$/
+worker-events: handler event;  source=content_by_lua, event=request4, pid=\d+, data=01234567890
+worker-events: handling event; source=content_by_lua, event=request6, pid=\d+, data=01234567890
+worker-events: handler event;  source=content_by_lua, event=request6, pid=\d+, data=01234567890$/
 --- timeout: 6
 
 


### PR DESCRIPTION
In the initialization phase the eventhandling timer does not run
because it does not yield. Hence timeouts occur if initialization
takes too long.
We remove timeouts and ttls and rely on lru eviction to remove the
oldest events from the shm. This reduces an option and prevents
timeouts.

Fixes #9 