### PR TITLE
Fix doc typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ nginx
 ctags
 tags
 a.lua
+.idea/

--- a/README.markdown
+++ b/README.markdown
@@ -256,7 +256,7 @@ already in a polling-loop, or `nil + error` if something went wrong.
 The `false` result generally happens when posting an event from an eventhandler. The
 eventhandler was called from `poll`, and when posting an event, the post methods will
 also call `poll` after posting the event, causing a loop. The `false` result simply
-means that the event was succesfully posted, but not handled yet, due to other
+means that the event was successfully posted, but not handled yet, due to other
 events ahead of it that need to be handled first.
 
 [Back to TOC](#table-of-contents)

--- a/lib/resty/worker/events.lua
+++ b/lib/resty/worker/events.lua
@@ -56,7 +56,7 @@ local DEFAULT_INTERVAL = 1
 local DEFAULT_WAIT_MAX = 0.5
 local DEFAULT_WAIT_INTERVAL = 0.010
 
--- creates a new level strcuture for the callback tree
+-- creates a new level structure for the callback tree
 local new_struct = function()
   return {
     weak_count = 0,
@@ -442,7 +442,7 @@ end
 -- Will remove both the weak and strong references.
 -- @param callback the eventhandler callback to remove
 -- @return `true` if it was removed, `false` if it was not in the list. If multiple
--- eventnames have been specified, `true` means at least 1 occurence was removed
+-- eventnames have been specified, `true` means at least 1 occurrence was removed
 _M.unregister = function(callback, source, ...)
   assert(type(callback) == "function", "expected function, got: "..
          type(callback))


### PR DESCRIPTION
Fix doc typos.
Add Intellij IDEA metadata dir to `.gitignore`.