### PR TITLE
fix(post) new 'shm_retry' option to counter 'no-memory' errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,6 +62,7 @@ http {
 
             wait_interval = 0.010,  -- wait before retry fetching event data
             wait_max = 0.5,         -- max wait time before discarding event
+            shm_retry = 5,          -- retries for shm fragmentation (no memory)
         }
         if not ok then
             ngx.log(ngx.ERR, "failed to start event system: ", err)
@@ -143,6 +144,10 @@ Will initialize the event listener. The `opts` parameter is a Lua table with nam
 * `shm`: (required) name of the shared memory to use. Event data will not expire, so
   the module relies on the shm lru mechanism to evict old events from the shm. As such
   the shm should probably not be used for other purposes.
+* `shm_retry`: (optional) number of retries when the shm returns "no memory" on
+  posting an event, default 5. The "no memory" error occurs when there is memory
+  fragmentation in the shm. On each try more entries will be evicted from the shm,
+  until there is a large enough contiguous memory block available for the new event data.
 * `interval`: (optional) interval to poll for events (in seconds), default 1
 * `wait_interval`: (optional) interval between two tries when a new eventid is found, but the
   data is not available yet (due to asynchronous behaviour of the worker processes)
@@ -401,6 +406,8 @@ Note: please update version number in the code when releasing a new version!
 
 - BREAKING: the return values from `poll` (and hence also `post` and `post_local`)
   changed to be more lua-ish, to be truthy when all is well.
+- feature: new option `shm_retry` to fix "no memory" errors caused by memory
+  fragmentation in the shm when posting events.
 - fix: fixed two typos in variable names (edge cases)
 
 0.3.3, 8-May-2018

--- a/README.markdown
+++ b/README.markdown
@@ -62,7 +62,7 @@ http {
 
             wait_interval = 0.010,  -- wait before retry fetching event data
             wait_max = 0.5,         -- max wait time before discarding event
-            shm_retry = 5,          -- retries for shm fragmentation (no memory)
+            shm_retries = 5,        -- retries for shm fragmentation (no memory)
         }
         if not ok then
             ngx.log(ngx.ERR, "failed to start event system: ", err)
@@ -144,10 +144,13 @@ Will initialize the event listener. The `opts` parameter is a Lua table with nam
 * `shm`: (required) name of the shared memory to use. Event data will not expire, so
   the module relies on the shm lru mechanism to evict old events from the shm. As such
   the shm should probably not be used for other purposes.
-* `shm_retry`: (optional) number of retries when the shm returns "no memory" on
-  posting an event, default 5. The "no memory" error occurs when there is memory
-  fragmentation in the shm. On each try more entries will be evicted from the shm,
-  until there is a large enough contiguous memory block available for the new event data.
+* `shm_retries`: (optional) number of retries when the shm returns "no memory" on posting
+  an event, default 5. Each time there is an insertion attempt and no memory is available
+  (either no space is available or the memory is available but fragmented), "up to tens"
+  of old entries are evicted. After that, if there's still no memory available, the
+  "no memory" error is returned. Retrying the insertion triggers the eviction phase
+  several times, increasing the memory available as well as the probability of finding a
+  large enough contiguous memory block available for the new event data.
 * `interval`: (optional) interval to poll for events (in seconds), default 1
 * `wait_interval`: (optional) interval between two tries when a new eventid is found, but the
   data is not available yet (due to asynchronous behaviour of the worker processes)
@@ -406,7 +409,7 @@ Note: please update version number in the code when releasing a new version!
 
 - BREAKING: the return values from `poll` (and hence also `post` and `post_local`)
   changed to be more lua-ish, to be truthy when all is well.
-- feature: new option `shm_retry` to fix "no memory" errors caused by memory
+- feature: new option `shm_retries` to fix "no memory" errors caused by memory
   fragmentation in the shm when posting events.
 - fix: fixed two typos in variable names (edge cases)
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -841,7 +841,7 @@ init_worker_by_lua '
             local we = require "resty.worker.events"
             local ok, err = we.configure{
                 shm = "worker_events",
-                shm_retry = 999,
+                shm_retries = 999,
             }
 
             -- fill the shm
@@ -850,11 +850,7 @@ init_worker_by_lua '
             end
 
             local ok, err = we.post("source", "event", ("y"):rep(1024):rep(500))
-            if ok then
-                ngx.say(ok)
-            else
-                ngx.say(err)
-            end
+            ngx.say(ok or err)
         ';
     }
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -9,7 +9,7 @@ use Cwd qw(cwd);
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 6 - 5);
+plan tests => repeat_each() * (blocks() * 6 - 9);
 
 my $pwd = cwd();
 
@@ -810,3 +810,55 @@ ok
 something went wrong here!
 in function 'error_func'
 in function 'in_between'
+
+
+
+=== TEST 11: shm fragmentation
+--- http_config eval
+"$::HttpConfig"
+. q{
+upstream foo.com {
+    server 127.0.0.1:12354;
+}
+
+server {
+    listen 12354;
+    location = /status {
+        return 200;
+    }
+}
+
+lua_shared_dict worker_events 1m;
+init_worker_by_lua '
+    ngx.shared.worker_events:flush_all()
+';
+}
+--- config
+    location = /t {
+        access_log off;
+        content_by_lua '
+            ngx.shared.worker_events:flush_all()
+            local we = require "resty.worker.events"
+            local ok, err = we.configure{
+                shm = "worker_events",
+                shm_retry = 999,
+            }
+
+            -- fill the shm
+            for i = 1, 1500000 do
+                ngx.shared.worker_events:add(i, tostring(i))
+            end
+
+            local ok, err = we.post("source", "event", ("y"):rep(1024):rep(500))
+            if ok then
+                ngx.say(ok)
+            else
+                ngx.say(err)
+            end
+        ';
+    }
+
+--- request
+GET /t
+--- response_body
+done


### PR DESCRIPTION
retries posting events when there is a "no memory" error.

fixes #19