### PR TITLE
feat(events) asynchronous post

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -327,10 +327,8 @@ the other workers will ignore it. Also any follow up events with the same `uniqu
 value will be ignored (for the `timeout` period specified to [configure](#configure)).
 The process executing the event will not necessarily be the process posting the event.
 
-Before returning, it will call [poll](#poll) to handle all events up to and including the newly posted
-event. Check the return value to make sure it completed, see `poll`.
-
-The return value will be the result from `poll`.
+The return value will be `true` when the event was successfully posted or
+`nil + error` in case of failure.
 
 *Note*: the worker process sending the event, will also receive the event! So if
 the eventsource will also act upon the event, it should not do so from the event
@@ -342,13 +340,12 @@ post_local
 ----------
 `syntax: success, err = events.post_local(source, event, data)`
 
-The same as [post](#post) except that the event will be local to the worker process, it will not
-be broadcasted to other workers. With this method, the `data` element will not be jsonified.
+The same as [post](#post) except that the event will be local to the worker process,
+it will not be broadcasted to other workers. With this method, the `data` element
+will not be jsonified.
 
-Before returning, it will call [poll](#poll) to first handle the posted event and then handle all
-other newly posted events. Check the return value to make sure it completed, see `poll`.
-
-The return value will be the result from `poll`.
+The return value will be `true` when the event was successfully posted or
+`nil + error` in case of failure.
 
 [Back to TOC](#table-of-contents)
 
@@ -451,8 +448,11 @@ History
 
 Note: please update version number in the code when releasing a new version!
 
-1.1.0, unreleased
+2.0.0, unreleased
 
+- BREAKING: the `post` function does not call `poll` anymore, making all events
+  asynchronous. When an immediate treatment to an event is needed an explicit
+  call to `poll` must be done.
 - fix: improved logging in case of failure to write to shm (add payload size
   for troubleshooting purposes)
 - fix: do not log the payload anymore, since it might expose sensitive data

--- a/lib/resty/worker/events.lua
+++ b/lib/resty/worker/events.lua
@@ -257,7 +257,8 @@ end
 -- @param data the data for the event, anything as long as it can be used with cjson
 -- @param unique a unique identifier for this event, providing it will make only 1
 -- worker execute the event
--- @return results from the call to `poll`, or nil+error
+-- @return true if the event was successfully posted, nil+error if there was an
+-- error posting the event
 _M.post = function(source, event, data, unique)
 
   if type(source) ~= "string" or source == "" then
@@ -272,15 +273,16 @@ _M.post = function(source, event, data, unique)
     err = 'failed posting event "'..event..'" by "'..
           source..'"; '..tostring(err)
     log(ERR, "worker-events: ", err)
-    return success, err
+    return nil, err
   end
 
-  return _M.poll()
+  return true
 end
 
--- the same as post. But the event will only be handled in the worker
+-- Similar to `post`, but synchronous. The event will be immediately executed
+-- and will not require a call to `poll`. It will only be handled in the worker
 -- it was posted from, it will not be broadcasted to other worker processes.
--- @return results from the call to `poll`, or nil+error
+-- @return `true` or nil+error
 _M.post_local = function(source, event, data)
   if type(source) ~= "string" or source == "" then
     return nil, "source is required"
@@ -291,7 +293,7 @@ _M.post_local = function(source, event, data)
 
   do_event(source, event, data, nil)
 
-  return _M.poll()
+  return true
 end
 
 -- flag to indicate we're already in a polling loop


### PR DESCRIPTION
This changes the `post` function behavior, as it does not call `poll` implicitly anymore, making all events to be truly asynchronous. 

With the removal of the implicit `poll` call, we avoid calling disabled APIs when posting events in some request phases.