### PR TITLE
chore(post) log stacktrace on error

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -446,9 +446,13 @@ History
 - push commit and tags
 - upload to luarocks
 
+### unreleased
+
+- chore: add stacktrace to `post` errors for better debug information.
+
 ### 2.0.1, 28-June-2021
 
-- fix: possible deadlock in the 'init phase
+- fix: possible deadlock in the `init` phase
 
 ### 2.0.0, 16-September-2020
 

--- a/lib/resty/worker/events.lua
+++ b/lib/resty/worker/events.lua
@@ -290,7 +290,7 @@ _M.post = function(source, event, data, unique)
   if not success then
     err = 'failed posting event "' .. event .. '" by "' ..
           source .. '"; ' .. tostring(err)
-    log(ERR, "worker-events: ", err)
+    log(ERR, "worker-events: ", debug.traceback(err))
     return nil, err
   end
 


### PR DESCRIPTION
this eases debugging because it allows to identify the calling code