### PR TITLE
chore(configure) remove redundant type check of unique_timeout

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -448,6 +448,7 @@ History
 
 ### unreleased
 
+- chore: remove redundant type checking of unique_timeout.
 - chore: add stacktrace to `post` errors for better debug information.
 
 ### 2.0.1, 28-June-2021

--- a/lib/resty/worker/events.lua
+++ b/lib/resty/worker/events.lua
@@ -611,7 +611,7 @@ _M.configure = function(opts)
 
   local unique_timeout = opts.timeout or
                          (_unique_timeout or DEFAULT_UNIQUE_TIMEOUT)
-  if type(unique_timeout) ~= "number" and unique_timeout ~= nil then
+  if type(unique_timeout) ~= "number" then
     return nil, 'optional "timeout" option must be a number'
   end
   if unique_timeout <= 0 then


### PR DESCRIPTION
Hello! 

The check of `unique_timeout ~= nil` is invalid for two reasons:

1. unique_timeout can't be nil by all means in the context.
2. If unique_timeout is nil really, the following camparing with 0 will go wrong.

So maybe just remove it will be better.